### PR TITLE
Reframe as 'Additional MLS Credentials'

### DIFF
--- a/draft-barnes-mls-addl-creds.md
+++ b/draft-barnes-mls-addl-creds.md
@@ -44,7 +44,7 @@ informative:
 
 --- abstract
 
-This specification defines two new kinds of credential for use within the
+This specification defines two new kinds of credentials for use within the
 Message Layer Security (MLS) credential framework: UserInfo Verifiable
 Credentials and multi-credentials.  UserInfo Verifiable Credentials allow
 clients to present credentials that associate OpenID Connect attributes to a

--- a/draft-barnes-mls-addl-creds.md
+++ b/draft-barnes-mls-addl-creds.md
@@ -89,8 +89,8 @@ document are to be interpreted as described in RFC 2119 [RFC2119].
 
 This specification uses terms from the MLS Protocol specification.  In
 particular, we refer to the MLS Credential object, which represents an
-association between a client's identity and the signature key that the client
-will use to messages in the MLS key exchange protocol.
+association between a client's identity and the signature key pair that the
+client will use to sign messages in the MLS key exchange protocol.
 
 # UserInfo Verifiable Credentials
 
@@ -291,7 +291,7 @@ struct {
 } WeakMultiCredential;
 ~~~
 
-The two types of credential are processed in exactly the same way.  The only
+The two types of credentials are processed in exactly the same way.  The only
 difference is in how they are treated when evaluating support by other clients,
 as discussed below.
 
@@ -316,7 +316,7 @@ struct {
 
 The `cipher_suite` for a credential is NOT REQUIRED to match the cipher suite
 for the MLS group in which it is used, but MUST meet the support requirements
-discussed below.
+with regard to support by group members discussed below.
 
 ## Verifying a Multi-Credential
 
@@ -330,7 +330,7 @@ following checks for each binding in the multi-credential:
 * The `signature` field is valid with respect to the `signature_key` value in
   the leaf node.
 
-* Each members of the group supports the credential type of the credential
+* Each member of the group supports the credential type of the credential
   (`multi` or `weak-multi`), and in addition:
   * For `multi`: Each member supports the cipher suite and credential type
     values for every credential binding in the multi-credential.
@@ -340,7 +340,7 @@ following checks for each binding in the multi-credential:
 # Security Considerations
 
 The validation procedures for UserInfoVC credentials verify that a JWT came from
-a given issuer.  It doesn't veirfy that the issuer is authorative for the
+a given issuer.  It doesn't verify that the issuer is authorative for the
 claimed attributes.  The client needs to verify that the issuer is trusted to
 assert the claimed attributes.
 

--- a/draft-barnes-mls-addl-creds.md
+++ b/draft-barnes-mls-addl-creds.md
@@ -3,7 +3,7 @@ title: "Additional MLS Credentials"
 abbrev: "Additional MLS Credentials"
 category: info
 
-docname: draft-barnes-mls-userinfo-vc-latest
+docname: draft-barnes-mls-addl-creds-latest
 submissiontype: IETF
 number:
 date:


### PR DESCRIPTION
This PR reframes the document as an "Additional MLS Credentials" document instead of just a UserInfo VC document.  We do this in order to add a "multi-credential" format.